### PR TITLE
Add latency calculation to binding requests

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -41,10 +41,10 @@ type Agent struct {
 	afterRunFn []func(ctx context.Context)
 	muAfterRun sync.Mutex
 
-	onConnectionStateChangeHdlr       atomic.Value // func(ConnectionState)
-	onSelectedCandidatePairChangeHdlr atomic.Value // func(Candidate, Candidate)
-	onCandidateHdlr                   atomic.Value // func(Candidate)
-	onSuccessfulBindingResponseHdlr   atomic.Value // func(Candidate)
+	onConnectionStateChangeHdlr                 atomic.Value // func(ConnectionState)
+	onSelectedCandidatePairChangeHdlr           atomic.Value // func(Candidate, Candidate)
+	onCandidateHdlr                             atomic.Value // func(Candidate)
+	onSuccessfulSelectedPairBindingResponseHdlr atomic.Value // func(*Candidate)
 
 	// State owned by the taskLoop
 	onConnected     chan struct{}

--- a/agent.go
+++ b/agent.go
@@ -15,8 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	atomicx "github.com/pion/ice/v3/internal/atomic"
-	stunx "github.com/pion/ice/v3/internal/stun"
 	"github.com/pion/logging"
 	"github.com/pion/mdns"
 	"github.com/pion/stun/v2"
@@ -25,6 +23,9 @@ import (
 	"github.com/pion/transport/v3/stdnet"
 	"github.com/pion/transport/v3/vnet"
 	"golang.org/x/net/proxy"
+
+	atomicx "github.com/pion/ice/v3/internal/atomic"
+	stunx "github.com/pion/ice/v3/internal/stun"
 )
 
 type bindingRequest struct {
@@ -43,6 +44,7 @@ type Agent struct {
 	onConnectionStateChangeHdlr       atomic.Value // func(ConnectionState)
 	onSelectedCandidatePairChangeHdlr atomic.Value // func(Candidate, Candidate)
 	onCandidateHdlr                   atomic.Value // func(Candidate)
+	onSuccessfulBindingResponseHdlr   atomic.Value // func(Candidate)
 
 	// State owned by the taskLoop
 	onConnected     chan struct{}
@@ -648,7 +650,8 @@ func (a *Agent) checkKeepalive() {
 
 	if (a.keepaliveInterval != 0) &&
 		((time.Since(selectedPair.Local.LastSent()) > a.keepaliveInterval) ||
-			(time.Since(selectedPair.Remote.LastReceived()) > a.keepaliveInterval)) {
+			(time.Since(selectedPair.Remote.LastReceived()) > a.keepaliveInterval) ||
+			(time.Since(selectedPair.lastBindingRequest) > a.keepaliveInterval)) {
 		// We use binding request instead of indication to support refresh consent schemas
 		// see https://tools.ietf.org/html/rfc7675
 		a.selector.PingCandidate(selectedPair.Local, selectedPair.Remote)
@@ -991,6 +994,9 @@ func (a *Agent) sendBindingRequest(m *stun.Message, local, remote Candidate) {
 		isUseCandidate: m.Contains(stun.AttrUseCandidate),
 	})
 
+	p := a.findPair(local, remote)
+	p.markBindingRequest(m.TransactionID)
+
 	a.sendSTUN(m, local, remote)
 }
 
@@ -1174,7 +1180,7 @@ func (a *Agent) GetSelectedCandidatePair() (*CandidatePair, error) {
 		return nil, err
 	}
 
-	return &CandidatePair{Local: local, Remote: remote}, nil
+	return &CandidatePair{Local: local, Remote: remote, latency: selectedPair.Latency()}, nil
 }
 
 func (a *Agent) getSelectedPair() *CandidatePair {

--- a/agent_handlers.go
+++ b/agent_handlers.go
@@ -23,6 +23,12 @@ func (a *Agent) OnCandidate(f func(Candidate)) error {
 	return nil
 }
 
+// OnSuccessfulBindingResponse sets a handler that is fired when a successful binding response is received
+func (a *Agent) OnSuccessfulBindingResponse(f func(*CandidatePair)) error {
+	a.onSuccessfulBindingResponseHdlr.Store(f)
+	return nil
+}
+
 func (a *Agent) onSelectedCandidatePairChange(p *CandidatePair) {
 	if h, ok := a.onSelectedCandidatePairChangeHdlr.Load().(func(Candidate, Candidate)); ok {
 		h(p.Local, p.Remote)
@@ -38,6 +44,12 @@ func (a *Agent) onCandidate(c Candidate) {
 func (a *Agent) onConnectionStateChange(s ConnectionState) {
 	if hdlr, ok := a.onConnectionStateChangeHdlr.Load().(func(ConnectionState)); ok {
 		hdlr(s)
+	}
+}
+
+func (a *Agent) onSuccessfulBindingResponse(p *CandidatePair) {
+	if h, ok := a.onSuccessfulBindingResponseHdlr.Load().(func(*CandidatePair)); ok {
+		h(p)
 	}
 }
 

--- a/agent_handlers.go
+++ b/agent_handlers.go
@@ -23,9 +23,9 @@ func (a *Agent) OnCandidate(f func(Candidate)) error {
 	return nil
 }
 
-// OnSuccessfulBindingResponse sets a handler that is fired when a successful binding response is received
-func (a *Agent) OnSuccessfulBindingResponse(f func(*CandidatePair)) error {
-	a.onSuccessfulBindingResponseHdlr.Store(f)
+// OnSuccessfulSelectedPairBindingResponse sets a handler that is fired when a successful binding response is received for the selected candidate pair
+func (a *Agent) OnSuccessfulSelectedPairBindingResponse(f func(*CandidatePair)) error {
+	a.onSuccessfulSelectedPairBindingResponseHdlr.Store(f)
 	return nil
 }
 
@@ -47,8 +47,8 @@ func (a *Agent) onConnectionStateChange(s ConnectionState) {
 	}
 }
 
-func (a *Agent) onSuccessfulBindingResponse(p *CandidatePair) {
-	if h, ok := a.onSuccessfulBindingResponseHdlr.Load().(func(*CandidatePair)); ok {
+func (a *Agent) onSuccessfulSelectedPairBindingResponse(p *CandidatePair) {
+	if h, ok := a.onSuccessfulSelectedPairBindingResponseHdlr.Load().(func(*CandidatePair)); ok {
 		h(p)
 	}
 }

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -110,12 +110,13 @@ func (p *CandidatePair) markBindingRequest(transactionID [12]byte) {
 	p.lastBindingTransactionID = transactionID
 }
 
-func (p *CandidatePair) markBindingResponse(transactionID [12]byte) {
+func (p *CandidatePair) markBindingResponse(transactionID [12]byte) bool {
 	if p.lastBindingRequest.IsZero() || transactionID != p.lastBindingTransactionID {
-		return
+		return false
 	}
 
 	p.latency = time.Since(p.lastBindingRequest)
+	return true
 }
 
 func (p *CandidatePair) Latency() time.Duration {

--- a/candidatepair.go
+++ b/candidatepair.go
@@ -19,6 +19,8 @@ func newCandidatePair(local, remote Candidate, controlling bool) *CandidatePair 
 	}
 }
 
+type TransactionID [stun.TransactionIDSize]byte
+
 // CandidatePair is a combination of a
 // local and remote candidate
 type CandidatePair struct {
@@ -27,7 +29,7 @@ type CandidatePair struct {
 	Local                    Candidate
 	latency                  time.Duration
 	lastBindingRequest       time.Time
-	lastBindingTransactionID [12]byte
+	lastBindingTransactionID TransactionID
 	bindingRequestCount      uint16
 	state                    CandidatePairState
 	nominated                bool
@@ -105,12 +107,12 @@ func (a *Agent) sendSTUN(msg *stun.Message, local, remote Candidate) {
 	}
 }
 
-func (p *CandidatePair) markBindingRequest(transactionID [12]byte) {
+func (p *CandidatePair) markBindingRequest(transactionID TransactionID) {
 	p.lastBindingRequest = time.Now()
 	p.lastBindingTransactionID = transactionID
 }
 
-func (p *CandidatePair) markBindingResponse(transactionID [12]byte) bool {
+func (p *CandidatePair) markBindingResponse(transactionID TransactionID) bool {
 	if p.lastBindingRequest.IsZero() || transactionID != p.lastBindingTransactionID {
 		return false
 	}

--- a/selection.go
+++ b/selection.go
@@ -139,6 +139,9 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 		return
 	}
 
+	p.markBindingResponse(m.TransactionID)
+	s.agent.onSuccessfulBindingResponse(p)
+
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)
 	if pendingRequest.isUseCandidate && s.agent.getSelectedPair() == nil {
@@ -229,6 +232,9 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 		s.log.Error("Success response from invalid candidate pair")
 		return
 	}
+
+	p.markBindingResponse(m.TransactionID)
+	s.agent.onSuccessfulBindingResponse(p)
 
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)

--- a/selection.go
+++ b/selection.go
@@ -139,13 +139,15 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 		return
 	}
 
-	p.markBindingResponse(m.TransactionID)
-	s.agent.onSuccessfulBindingResponse(p)
-
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)
 	if pendingRequest.isUseCandidate && s.agent.getSelectedPair() == nil {
 		s.agent.setSelectedPair(p)
+	}
+
+	ok = p.markBindingResponse(m.TransactionID)
+	if ok && s.agent.getSelectedPair() == p {
+		s.agent.onSuccessfulSelectedPairBindingResponse(p)
 	}
 }
 
@@ -233,8 +235,10 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 		return
 	}
 
-	p.markBindingResponse(m.TransactionID)
-	s.agent.onSuccessfulBindingResponse(p)
+	ok = p.markBindingResponse(m.TransactionID)
+	if ok {
+		s.agent.onSuccessfulSelectedPairBindingResponse(p)
+	}
 
 	p.state = CandidatePairStateSucceeded
 	s.log.Tracef("Found valid candidate pair: %s", p)


### PR DESCRIPTION
In this PR we extend the binding requests to calculayte a latency based on how lon the requests take and add those to the selected candidate pairs. This PR increases the healthcheck period for the controling agent so that both sides are sending a healthcheck message (and therefor latency check) every 4 seconds.